### PR TITLE
Add a CI pipeline to main branch

### DIFF
--- a/.github/workflows/aws-nonprod.yml
+++ b/.github/workflows/aws-nonprod.yml
@@ -1,0 +1,64 @@
+name: Deploy to Amazon ECS (NonProd)
+
+on: workflow_dispatch
+
+env:
+  ECR_REPOSITORY: frontends-librarian
+  ECS_SERVICE: frontends-librarian
+  ECS_CLUSTER: geekway-nonprod
+  ECS_TASK_DEFINITION: librarian/.aws/taskdefinition-nonprod.json          
+  CONTAINER_NAME: frontends-librarian
+                                               
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+    - name: Fill in the new image ID in the Amazon ECS task definition
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: ${{ env.ECS_TASK_DEFINITION }}
+        container-name: ${{ env.CONTAINER_NAME }}
+        image: ${{ steps.build-image.outputs.image }}
+
+    - name: Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: ${{ env.ECS_SERVICE }}
+        cluster: ${{ env.ECS_CLUSTER }}
+        wait-for-service-stability: true


### PR DESCRIPTION
This adds a Github Action that 
* Creates a Docker image of the librarian app 
* Pushes the image to ECR
* Passes the new image ID to the task definition
* Redeploys the service with the new image

This work follows the instructions in [Deploying to Amazon Elastic Container Service](https://docs.github.com/en/actions/deployment/deploying-to-your-cloud-provider/deploying-to-amazon-elastic-container-service) and the corresponding workflow file in the ruleslawyer project (`/.aws/aws-nonprod.yml`).

```on: workflow_dispatch``` means that the workflow is only triggered manually.