### PR TITLE
Reduce ECS instance sizes

### DIFF
--- a/board-game-admin/.aws/taskdefinition-nonprod.json
+++ b/board-game-admin/.aws/taskdefinition-nonprod.json
@@ -71,8 +71,8 @@
 	"requiresCompatibilities": [
 			"FARGATE"
 	],
-	"cpu": "1024",
-	"memory": "3072",
+	"cpu": "256",
+	"memory": "512",
 	"tags": [],
 	"runtimePlatform": {
 			"cpuArchitecture": "X86_64",

--- a/librarian/.aws/taskdefinition-nonprod.json
+++ b/librarian/.aws/taskdefinition-nonprod.json
@@ -75,8 +75,8 @@
 	"requiresCompatibilities": [
 			"FARGATE"
 	],
-	"cpu": "1024",
-	"memory": "3072",
+	"cpu": "256",
+	"memory": "512",
 	"tags": [],
 	"runtimePlatform": {
 			"cpuArchitecture": "X86_64",

--- a/play-prize-entry/.aws/taskdefinition-nonprod.json
+++ b/play-prize-entry/.aws/taskdefinition-nonprod.json
@@ -67,8 +67,8 @@
 	"requiresCompatibilities": [
 			"FARGATE"
 	],
-	"cpu": "1024",
-	"memory": "3072",
+	"cpu": "256",
+	"memory": "512",
 	"tags": [],
 	"runtimePlatform": {
 			"cpuArchitecture": "X86_64",


### PR DESCRIPTION
CloudWatch metrics show that we're using a small percentage of the compute configured for each instance. This PR reduces the size of instance configured in task definitions.