### PR TITLE
Adding a prod deploy GHA

### DIFF
--- a/.github/workflows/aws-prod.yml
+++ b/.github/workflows/aws-prod.yml
@@ -1,0 +1,47 @@
+name: Deploy to Amazon ECS (Prod)
+
+on: workflow_dispatch
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-librarian:
+    uses: ./.github/workflows/build-and-deploy.yml
+    with:
+      ecr-repository: frontends-librarian
+      ecs-service: frontend-librarian
+      ecs-task-definition: librarian/.aws/taskdefinition-prod.json
+      container-name: frontends-librarian
+      ecs-cluster: geekway-prod
+      folder-name: librarian
+      always-override-limit: false
+      auth-callback: https://library.geekway.com/librarian
+      logout-return-url: https://library.geekway.com/librarian
+    secrets: inherit
+  deploy-admin:
+    uses: ./.github/workflows/build-and-deploy.yml
+    with:
+      ecr-repository: frontends-admin
+      ecs-service: frontend-admin
+      ecs-task-definition: board-game-admin/.aws/taskdefinition-prod.json
+      container-name: frontends-admin
+      ecs-cluster: geekway-prod
+      folder-name: board-game-admin
+      always-override-limit: false
+      auth-callback: https://library.geekway.com/admin
+      logout-return-url: https://library.geekway.com/admin
+    secrets: inherit
+  deploy-play-and-win:
+    uses: ./.github/workflows/build-and-deploy.yml
+    with:
+      ecr-repository: frontends-play-and-win
+      ecs-service: frontend-playandwin
+      ecs-task-definition: play-prize-entry/.aws/taskdefinition-prod.json
+      container-name: frontends-play-and-win
+      ecs-cluster: geekway-prod
+      folder-name: play-prize-entry
+      always-override-limit: false
+      auth-callback: https://library.geekway.com/playandwin
+      logout-return-url: https://library.geekway.comcom/playandwin
+    secrets: inherit

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -70,18 +70,18 @@ jobs:
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-    - name: Fill in the new image ID in the Amazon ECS task definition
-      id: task-def
-      uses: aws-actions/amazon-ecs-render-task-definition@v1
-      with:
-        task-definition: ${{ inputs.ecs-task-definition }}
-        container-name: ${{ inputs.container-name }}
-        image: ${{ steps.build-image.outputs.image }}
+    # - name: Fill in the new image ID in the Amazon ECS task definition
+    #   id: task-def
+    #   uses: aws-actions/amazon-ecs-render-task-definition@v1
+    #   with:
+    #     task-definition: ${{ inputs.ecs-task-definition }}
+    #     container-name: ${{ inputs.container-name }}
+    #     image: ${{ steps.build-image.outputs.image }}
 
-    - name: Deploy Amazon ECS task definition
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-      with:
-        task-definition: ${{ steps.task-def.outputs.task-definition }}
-        service: ${{ inputs.ecs-service }}
-        cluster: ${{ inputs.ecs-cluster }}
-        wait-for-service-stability: true
+    # - name: Deploy Amazon ECS task definition
+    #   uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+    #   with:
+    #     task-definition: ${{ steps.task-def.outputs.task-definition }}
+    #     service: ${{ inputs.ecs-service }}
+    #     cluster: ${{ inputs.ecs-cluster }}
+    #     wait-for-service-stability: true


### PR DESCRIPTION
Commented out the ECS-related actions because we don't have task definitions set up yet. This will build and push images to ECR, which we'll use in the task definition.